### PR TITLE
Restrict to non-nullable types:

### DIFF
--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -835,7 +835,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1) {
+    static <E extends Object> List<E> of(E e1) {
         return new ImmutableCollections.List12<>(e1);
     }
 
@@ -852,7 +852,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2) {
+    static <E extends Object> List<E> of(E e1, E e2) {
         return new ImmutableCollections.List12<>(e1, e2);
     }
 
@@ -870,7 +870,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3) {
         return new ImmutableCollections.ListN<>(e1, e2, e3);
     }
 
@@ -889,7 +889,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4);
     }
 
@@ -909,7 +909,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4, E e5) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5);
     }
 
@@ -930,7 +930,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6);
     }
@@ -953,7 +953,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7);
     }
@@ -977,7 +977,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7, e8);
     }
@@ -1002,7 +1002,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7, e8, e9);
     }
@@ -1028,7 +1028,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7, e8, e9, e10);
     }
@@ -1060,7 +1060,7 @@ public interface List<E> extends Collection<E> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    static <E> List<E> of(E... elements) {
+    static <E extends Object> List<E> of(E... elements) {
         switch (elements.length) { // implicit null check of elements
             case 0:
                 return ImmutableCollections.emptyList();
@@ -1089,7 +1089,7 @@ public interface List<E> extends Collection<E> {
      * @throws NullPointerException if coll is null, or if it contains any nulls
      * @since 10
      */
-    static <E> List<E> copyOf(Collection<? extends E> coll) {
+    static <E extends Object> List<E> copyOf(Collection<? extends E> coll) {
         return ImmutableCollections.listCopy(coll);
     }
 }

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1345,7 +1345,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1) {
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1) {
         return new ImmutableCollections.Map1<>(k1, v1);
     }
 
@@ -1365,7 +1365,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2) {
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2);
     }
 
@@ -1387,7 +1387,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3);
     }
 
@@ -1411,7 +1411,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4);
     }
 
@@ -1437,7 +1437,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
     }
 
@@ -1465,7 +1465,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6);
@@ -1497,7 +1497,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7);
@@ -1531,7 +1531,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7, K k8, V v8) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7, k8, v8);
@@ -1567,7 +1567,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7, k8, v8, k9, v9);
@@ -1605,7 +1605,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
@@ -1644,7 +1644,7 @@ public interface Map<K, V> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    static <K, V> Map<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
+    static <K extends Object, V extends Object> Map<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
         if (entries.length == 0) { // implicit null check of entries array
             return ImmutableCollections.emptyMap();
         } else if (entries.length == 1) {
@@ -1696,7 +1696,7 @@ public interface Map<K, V> {
      * @see Map#ofEntries Map.ofEntries()
      * @since 9
      */
-    static <K, V> Entry<K, V> entry(K k, V v) {
+    static <K extends Object, V extends Object> Entry<K, V> entry(K k, V v) {
         // KeyValueHolder checks for nulls
         return new KeyValueHolder<>(k, v);
     }
@@ -1719,7 +1719,7 @@ public interface Map<K, V> {
      * @since 10
      */
     @SuppressWarnings({"rawtypes","unchecked"})
-    static <K, V> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
+    static <K extends Object, V extends Object> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
         if (map instanceof ImmutableCollections.AbstractImmutableMap) {
             return (Map<K,V>)map;
         } else {

--- a/src/java.base/share/classes/java/util/Set.java
+++ b/src/java.base/share/classes/java/util/Set.java
@@ -483,7 +483,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1) {
+    static <E extends Object> Set<E> of(E e1) {
         return new ImmutableCollections.Set12<>(e1);
     }
 
@@ -500,7 +500,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2) {
+    static <E extends Object> Set<E> of(E e1, E e2) {
         return new ImmutableCollections.Set12<>(e1, e2);
     }
 
@@ -518,7 +518,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3) {
         return new ImmutableCollections.SetN<>(e1, e2, e3);
     }
 
@@ -537,7 +537,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4);
     }
 
@@ -557,7 +557,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5);
     }
 
@@ -578,7 +578,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6);
     }
@@ -601,7 +601,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7);
     }
@@ -625,7 +625,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7, e8);
     }
@@ -650,7 +650,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7, e8, e9);
     }
@@ -676,7 +676,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7, e8, e9, e10);
     }
@@ -709,7 +709,7 @@ public interface Set<E> extends Collection<E> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    static <E> Set<E> of(E... elements) {
+    static <E extends Object> Set<E> of(E... elements) {
         switch (elements.length) { // implicit null check of elements
             case 0:
                 return ImmutableCollections.emptySet();
@@ -740,7 +740,7 @@ public interface Set<E> extends Collection<E> {
      * @since 10
      */
     @SuppressWarnings("unchecked")
-    static <E> Set<E> copyOf(Collection<? extends E> coll) {
+    static <E extends Object> Set<E> copyOf(Collection<? extends E> coll) {
         if (coll instanceof ImmutableCollections.AbstractImmutableSet) {
             return (Set<E>)coll;
         } else {


### PR DESCRIPTION
- `Map`: `of`, `copyOf`, `ofEntries`, `entry`
- `List` and `Set`: `of`, `copyOf`

(except for _empty_ collections, which can have nullable types)