### PR TITLE
Annotate some `java.util.concurrent` collections.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
@@ -39,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.lang.ref.WeakReference;
 import java.util.AbstractQueue;
@@ -88,7 +89,8 @@ import java.util.function.Predicate;
  * @author Doug Lea
  * @param <E> the type of elements held in this queue
  */
-public class ArrayBlockingQueue<E> extends AbstractQueue<E>
+@AnnotatedFor({"nullness"})
+public class ArrayBlockingQueue<E extends Object> extends AbstractQueue<E>
         implements BlockingQueue<E>, java.io.Serializable {
 
     /*

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -39,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.util.AbstractQueue;
 import java.util.Collection;
@@ -80,7 +81,8 @@ import java.util.function.Predicate;
  * @author  Doug Lea
  * @param <E> the type of elements held in this deque
  */
-public class LinkedBlockingDeque<E>
+@AnnotatedFor({"nullness"})
+public class LinkedBlockingDeque<E extends Object>
     extends AbstractQueue<E>
     implements BlockingDeque<E>, java.io.Serializable {
 
@@ -459,7 +461,7 @@ public class LinkedBlockingDeque<E>
         return x;
     }
 
-    public E pollFirst() {
+    public @Nullable E pollFirst() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
@@ -469,7 +471,7 @@ public class LinkedBlockingDeque<E>
         }
     }
 
-    public E pollLast() {
+    public @Nullable E pollLast() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
@@ -505,7 +507,7 @@ public class LinkedBlockingDeque<E>
         }
     }
 
-    public E pollFirst(long timeout, TimeUnit unit)
+    public @Nullable E pollFirst(long timeout, TimeUnit unit)
         throws InterruptedException {
         long nanos = unit.toNanos(timeout);
         final ReentrantLock lock = this.lock;
@@ -523,7 +525,7 @@ public class LinkedBlockingDeque<E>
         }
     }
 
-    public E pollLast(long timeout, TimeUnit unit)
+    public @Nullable E pollLast(long timeout, TimeUnit unit)
         throws InterruptedException {
         long nanos = unit.toNanos(timeout);
         final ReentrantLock lock = this.lock;
@@ -559,7 +561,7 @@ public class LinkedBlockingDeque<E>
         return x;
     }
 
-    public E peekFirst() {
+    public @Nullable E peekFirst() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
@@ -569,7 +571,7 @@ public class LinkedBlockingDeque<E>
         }
     }
 
-    public E peekLast() {
+    public @Nullable E peekLast() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
@@ -668,7 +670,7 @@ public class LinkedBlockingDeque<E>
         return removeFirst();
     }
 
-    public E poll() {
+    public @Nullable E poll() {
         return pollFirst();
     }
 
@@ -676,7 +678,7 @@ public class LinkedBlockingDeque<E>
         return takeFirst();
     }
 
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public @Nullable E poll(long timeout, TimeUnit unit) throws InterruptedException {
         return pollFirst(timeout, unit);
     }
 
@@ -694,7 +696,7 @@ public class LinkedBlockingDeque<E>
         return getFirst();
     }
 
-    public E peek() {
+    public @Nullable E peek() {
         return peekFirst();
     }
 

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingQueue.java
@@ -39,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.util.AbstractQueue;
 import java.util.Collection;
@@ -83,7 +84,8 @@ import java.util.function.Predicate;
  * @author Doug Lea
  * @param <E> the type of elements held in this queue
  */
-public class LinkedBlockingQueue<E> extends AbstractQueue<E>
+@AnnotatedFor({"nullness"})
+public class LinkedBlockingQueue<E extends Object> extends AbstractQueue<E>
         implements BlockingQueue<E>, java.io.Serializable {
     private static final long serialVersionUID = -6903933977591709194L;
 
@@ -450,7 +452,7 @@ public class LinkedBlockingQueue<E> extends AbstractQueue<E>
         return x;
     }
 
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public @Nullable E poll(long timeout, TimeUnit unit) throws InterruptedException {
         final E x;
         final int c;
         long nanos = unit.toNanos(timeout);
@@ -475,7 +477,7 @@ public class LinkedBlockingQueue<E> extends AbstractQueue<E>
         return x;
     }
 
-    public E poll() {
+    public @Nullable E poll() {
         final AtomicInteger count = this.count;
         if (count.get() == 0)
             return null;
@@ -498,7 +500,7 @@ public class LinkedBlockingQueue<E> extends AbstractQueue<E>
         return x;
     }
 
-    public E peek() {
+    public @Nullable E peek() {
         final AtomicInteger count = this.count;
         if (count.get() == 0)
             return null;

--- a/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
@@ -39,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -115,8 +116,9 @@ import jdk.internal.misc.SharedSecrets;
  * @author Doug Lea
  * @param <E> the type of elements held in this queue
  */
+@AnnotatedFor({"nullness"})
 @SuppressWarnings("unchecked")
-public class PriorityBlockingQueue<E> extends AbstractQueue<E>
+public class PriorityBlockingQueue<E extends Object> extends AbstractQueue<E>
     implements BlockingQueue<E>, java.io.Serializable {
     private static final long serialVersionUID = 5595510919245408276L;
 
@@ -533,7 +535,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
         return offer(e); // never need to block
     }
 
-    public E poll() {
+    public @Nullable E poll() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
@@ -556,7 +558,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
         return result;
     }
 
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public @Nullable E poll(long timeout, TimeUnit unit) throws InterruptedException {
         long nanos = unit.toNanos(timeout);
         final ReentrantLock lock = this.lock;
         lock.lockInterruptibly();
@@ -570,7 +572,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
         return result;
     }
 
-    public E peek() {
+    public @Nullable E peek() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {


### PR DESCRIPTION
Split off from https://github.com/eisop/jdk/pull/9, which also contains
some changes whose usefulness is unclear.