### PR TITLE
Write `extends @NonNull Object` instead of `extends Object`.

### DIFF
--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
 import org.checkerframework.checker.lock.qual.ReleasesNoLocks;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.dataflow.qual.Pure;
@@ -835,7 +836,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1) {
+    static <E extends @NonNull Object> List<E> of(E e1) {
         return new ImmutableCollections.List12<>(e1);
     }
 
@@ -852,7 +853,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2) {
         return new ImmutableCollections.List12<>(e1, e2);
     }
 
@@ -870,7 +871,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3) {
         return new ImmutableCollections.ListN<>(e1, e2, e3);
     }
 
@@ -889,7 +890,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4);
     }
 
@@ -909,7 +910,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4, E e5) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5);
     }
 
@@ -930,7 +931,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6);
     }
@@ -953,7 +954,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7);
     }
@@ -977,7 +978,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7, e8);
     }
@@ -1002,7 +1003,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7, e8, e9);
     }
@@ -1028,7 +1029,7 @@ public interface List<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    static <E extends @NonNull Object> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
         return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
                                                 e6, e7, e8, e9, e10);
     }
@@ -1060,7 +1061,7 @@ public interface List<E> extends Collection<E> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    static <E extends Object> List<E> of(E... elements) {
+    static <E extends @NonNull Object> List<E> of(E... elements) {
         switch (elements.length) { // implicit null check of elements
             case 0:
                 return ImmutableCollections.emptyList();
@@ -1089,7 +1090,7 @@ public interface List<E> extends Collection<E> {
      * @throws NullPointerException if coll is null, or if it contains any nulls
      * @since 10
      */
-    static <E extends Object> List<E> copyOf(Collection<? extends E> coll) {
+    static <E extends @NonNull Object> List<E> copyOf(Collection<? extends E> coll) {
         return ImmutableCollections.listCopy(coll);
     }
 }

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1345,7 +1345,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1) {
         return new ImmutableCollections.Map1<>(k1, v1);
     }
 
@@ -1365,7 +1365,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2);
     }
 
@@ -1387,7 +1387,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3);
     }
 
@@ -1411,7 +1411,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4);
     }
 
@@ -1437,7 +1437,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
     }
 
@@ -1465,7 +1465,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6);
@@ -1497,7 +1497,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7);
@@ -1531,7 +1531,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7, K k8, V v8) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7, k8, v8);
@@ -1567,7 +1567,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7, k8, v8, k9, v9);
@@ -1605,7 +1605,7 @@ public interface Map<K, V> {
      *
      * @since 9
      */
-    static <K extends Object, V extends Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
         return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
                                                k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
@@ -1644,7 +1644,7 @@ public interface Map<K, V> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    static <K extends Object, V extends Object> Map<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
         if (entries.length == 0) { // implicit null check of entries array
             return ImmutableCollections.emptyMap();
         } else if (entries.length == 1) {
@@ -1696,7 +1696,7 @@ public interface Map<K, V> {
      * @see Map#ofEntries Map.ofEntries()
      * @since 9
      */
-    static <K extends Object, V extends Object> Entry<K, V> entry(K k, V v) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Entry<K, V> entry(K k, V v) {
         // KeyValueHolder checks for nulls
         return new KeyValueHolder<>(k, v);
     }
@@ -1719,7 +1719,7 @@ public interface Map<K, V> {
      * @since 10
      */
     @SuppressWarnings({"rawtypes","unchecked"})
-    static <K extends Object, V extends Object> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
+    static <K extends @NonNull Object, V extends @NonNull Object> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
         if (map instanceof ImmutableCollections.AbstractImmutableMap) {
             return (Map<K,V>)map;
         } else {

--- a/src/java.base/share/classes/java/util/Set.java
+++ b/src/java.base/share/classes/java/util/Set.java
@@ -27,6 +27,7 @@ package java.util;
 
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.dataflow.qual.Pure;
@@ -483,7 +484,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1) {
+    static <E extends @NonNull Object> Set<E> of(E e1) {
         return new ImmutableCollections.Set12<>(e1);
     }
 
@@ -500,7 +501,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2) {
         return new ImmutableCollections.Set12<>(e1, e2);
     }
 
@@ -518,7 +519,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3) {
         return new ImmutableCollections.SetN<>(e1, e2, e3);
     }
 
@@ -537,7 +538,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4);
     }
 
@@ -557,7 +558,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4, E e5) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5);
     }
 
@@ -578,7 +579,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6);
     }
@@ -601,7 +602,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7);
     }
@@ -625,7 +626,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7, e8);
     }
@@ -650,7 +651,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7, e8, e9);
     }
@@ -676,7 +677,7 @@ public interface Set<E> extends Collection<E> {
      *
      * @since 9
      */
-    static <E extends Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    static <E extends @NonNull Object> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
         return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
                                                e6, e7, e8, e9, e10);
     }
@@ -709,7 +710,7 @@ public interface Set<E> extends Collection<E> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    static <E extends Object> Set<E> of(E... elements) {
+    static <E extends @NonNull Object> Set<E> of(E... elements) {
         switch (elements.length) { // implicit null check of elements
             case 0:
                 return ImmutableCollections.emptySet();
@@ -740,7 +741,7 @@ public interface Set<E> extends Collection<E> {
      * @since 10
      */
     @SuppressWarnings("unchecked")
-    static <E extends Object> Set<E> copyOf(Collection<? extends E> coll) {
+    static <E extends @NonNull Object> Set<E> copyOf(Collection<? extends E> coll) {
         if (coll instanceof ImmutableCollections.AbstractImmutableSet) {
             return (Set<E>)coll;
         } else {

--- a/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
@@ -90,7 +90,7 @@ import java.util.function.Predicate;
  * @param <E> the type of elements held in this queue
  */
 @AnnotatedFor({"nullness"})
-public class ArrayBlockingQueue<E extends Object> extends AbstractQueue<E>
+public class ArrayBlockingQueue<E extends @NonNull Object> extends AbstractQueue<E>
         implements BlockingQueue<E>, java.io.Serializable {
 
     /*

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -82,7 +82,7 @@ import java.util.function.Predicate;
  * @param <E> the type of elements held in this deque
  */
 @AnnotatedFor({"nullness"})
-public class LinkedBlockingDeque<E extends Object>
+public class LinkedBlockingDeque<E extends @NonNull Object>
     extends AbstractQueue<E>
     implements BlockingDeque<E>, java.io.Serializable {
 

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingQueue.java
@@ -85,7 +85,7 @@ import java.util.function.Predicate;
  * @param <E> the type of elements held in this queue
  */
 @AnnotatedFor({"nullness"})
-public class LinkedBlockingQueue<E extends Object> extends AbstractQueue<E>
+public class LinkedBlockingQueue<E extends @NonNull Object> extends AbstractQueue<E>
         implements BlockingQueue<E>, java.io.Serializable {
     private static final long serialVersionUID = -6903933977591709194L;
 

--- a/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
@@ -118,7 +118,7 @@ import jdk.internal.misc.SharedSecrets;
  */
 @AnnotatedFor({"nullness"})
 @SuppressWarnings("unchecked")
-public class PriorityBlockingQueue<E extends Object> extends AbstractQueue<E>
+public class PriorityBlockingQueue<E extends @NonNull Object> extends AbstractQueue<E>
     implements BlockingQueue<E>, java.io.Serializable {
     private static final long serialVersionUID = 5595510919245408276L;
 

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -24,6 +24,7 @@
  */
 package java.util.stream;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
@@ -1187,7 +1188,7 @@ public final class Collectors {
      * @see #groupingByConcurrent(Function, Collector)
      * @see #groupingByConcurrent(Function, Supplier, Collector)
      */
-    public static <T, K extends Object>
+    public static <T, K extends @NonNull Object>
     Collector<T, ?, ConcurrentMap<K, List<T>>>
     groupingByConcurrent(Function<? super T, ? extends K> classifier) {
         return groupingByConcurrent(classifier, ConcurrentHashMap::new, toList());
@@ -1233,7 +1234,7 @@ public final class Collectors {
      * @see #groupingByConcurrent(Function)
      * @see #groupingByConcurrent(Function, Supplier, Collector)
      */
-    public static <T, K extends Object, A, D extends Object>
+    public static <T, K extends @NonNull Object, A, D extends @NonNull Object>
     Collector<T, ?, ConcurrentMap<K, D>> groupingByConcurrent(Function<? super T, ? extends K> classifier,
                                                               Collector<? super T, A, D> downstream) {
         return groupingByConcurrent(classifier, ConcurrentHashMap::new, downstream);
@@ -1281,7 +1282,7 @@ public final class Collectors {
      * @see #groupingByConcurrent(Function, Collector)
      * @see #groupingBy(Function, Supplier, Collector)
      */
-    public static <T, K extends Object, A, D extends Object, M extends ConcurrentMap<K, D>>
+    public static <T, K extends @NonNull Object, A, D extends @NonNull Object, M extends ConcurrentMap<K, D>>
     Collector<T, ?, M> groupingByConcurrent(Function<? super T, ? extends K> classifier,
                                             Supplier<M> mapFactory,
                                             Collector<? super T, A, D> downstream) {
@@ -1459,7 +1460,7 @@ public final class Collectors {
      * @see #toMap(Function, Function, BinaryOperator, Supplier)
      * @see #toConcurrentMap(Function, Function)
      */
-    public static <T, K, U extends Object>
+    public static <T, K, U extends @NonNull Object>
     Collector<T, ?, Map<K,U>> toMap(Function<? super T, ? extends K> keyMapper,
                                     Function<? super T, ? extends U> valueMapper) {
         return new CollectorImpl<>(HashMap::new,
@@ -1497,7 +1498,7 @@ public final class Collectors {
      * @since 10
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static <T, K extends Object, U extends Object>
+    public static <T, K extends @NonNull Object, U extends @NonNull Object>
     Collector<T, ?, Map<K,U>> toUnmodifiableMap(Function<? super T, ? extends K> keyMapper,
                                                 Function<? super T, ? extends U> valueMapper) {
         Objects.requireNonNull(keyMapper, "keyMapper");
@@ -1563,7 +1564,7 @@ public final class Collectors {
      * @see #toMap(Function, Function, BinaryOperator, Supplier)
      * @see #toConcurrentMap(Function, Function, BinaryOperator)
      */
-    public static <T, K, U extends Object>
+    public static <T, K, U extends @NonNull Object>
     Collector<T, ?, Map<K,U>> toMap(Function<? super T, ? extends K> keyMapper,
                                     Function<? super T, ? extends U> valueMapper,
                                     BinaryOperator<U> mergeFunction) {
@@ -1603,7 +1604,7 @@ public final class Collectors {
      * @since 10
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static <T, K extends Object, U extends Object>
+    public static <T, K extends @NonNull Object, U extends @NonNull Object>
     Collector<T, ?, Map<K,U>> toUnmodifiableMap(Function<? super T, ? extends K> keyMapper,
                                                 Function<? super T, ? extends U> valueMapper,
                                                 BinaryOperator<U> mergeFunction) {
@@ -1655,7 +1656,7 @@ public final class Collectors {
      * @see #toMap(Function, Function, BinaryOperator)
      * @see #toConcurrentMap(Function, Function, BinaryOperator, Supplier)
      */
-    public static <T, K, U extends Object, M extends Map<K, U>>
+    public static <T, K, U extends @NonNull Object, M extends Map<K, U>>
     Collector<T, ?, M> toMap(Function<? super T, ? extends K> keyMapper,
                              Function<? super T, ? extends U> valueMapper,
                              BinaryOperator<U> mergeFunction,
@@ -1718,7 +1719,7 @@ public final class Collectors {
      * @see #toConcurrentMap(Function, Function, BinaryOperator)
      * @see #toConcurrentMap(Function, Function, BinaryOperator, Supplier)
      */
-    public static <T, K extends Object, U extends Object>
+    public static <T, K extends @NonNull Object, U extends @NonNull Object>
     Collector<T, ?, ConcurrentMap<K,U>> toConcurrentMap(Function<? super T, ? extends K> keyMapper,
                                                         Function<? super T, ? extends U> valueMapper) {
         return new CollectorImpl<>(ConcurrentHashMap::new,
@@ -1777,7 +1778,7 @@ public final class Collectors {
      * @see #toConcurrentMap(Function, Function, BinaryOperator, Supplier)
      * @see #toMap(Function, Function, BinaryOperator)
      */
-    public static <T, K extends Object, U extends Object>
+    public static <T, K extends @NonNull Object, U extends @NonNull Object>
     Collector<T, ?, ConcurrentMap<K,U>>
     toConcurrentMap(Function<? super T, ? extends K> keyMapper,
                     Function<? super T, ? extends U> valueMapper,
@@ -1819,7 +1820,7 @@ public final class Collectors {
      * @see #toConcurrentMap(Function, Function, BinaryOperator)
      * @see #toMap(Function, Function, BinaryOperator, Supplier)
      */
-    public static <T, K extends Object, U extends Object, M extends ConcurrentMap<K, U>>
+    public static <T, K extends @NonNull Object, U extends @NonNull Object, M extends ConcurrentMap<K, U>>
     Collector<T, ?, M> toConcurrentMap(Function<? super T, ? extends K> keyMapper,
                                        Function<? super T, ? extends U> valueMapper,
                                        BinaryOperator<U> mergeFunction,


### PR DESCRIPTION
The simpler formulation doesn't work in stub files, even in JDK stubs.
(This is typetools bug number 3030.)

I tested against a file with the call:

```
java.util.List.of("", null);
```