### PR TITLE
Mark `java.math` as annotated for nullness.

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.PolyValue;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import static java.math.BigInteger.LONG_MASK;
 import java.io.IOException;
@@ -305,6 +306,7 @@ import java.util.Objects;
  * @author  Sergey V. Kuksenko
  * @since 1.1
  */
+@AnnotatedFor("nullness")
 public class BigDecimal extends Number implements Comparable<BigDecimal> {
     /**
      * The unscaled value of this BigDecimal, as returned by {@link

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -138,7 +138,7 @@ import jdk.internal.vm.annotation.Stable;
  * @since 1.1
  */
 
-@AnnotatedFor({"value"})
+@AnnotatedFor({"nullness", "value"})
 public class BigInteger extends Number implements Comparable<BigInteger> {
     /**
      * The signum of this BigInteger: -1 for negative, 0 for zero, or

--- a/src/java.base/share/classes/java/math/MathContext.java
+++ b/src/java.base/share/classes/java/math/MathContext.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.io.*;
 
@@ -58,7 +59,7 @@ import java.io.*;
  * @author  Joseph D. Darcy
  * @since 1.5
  */
-
+@AnnotatedFor("nullness")
 public final class MathContext implements Serializable {
 
     /* ----- Constants ----- */

--- a/src/java.base/share/classes/java/math/RoundingMode.java
+++ b/src/java.base/share/classes/java/math/RoundingMode.java
@@ -28,6 +28,8 @@
  */
 package java.math;
 
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Specifies a <i>rounding policy</i> for numerical operations capable
  * of discarding precision. Each rounding mode indicates how the least
@@ -102,6 +104,7 @@ package java.math;
  * @since 1.5
  */
 @SuppressWarnings("deprecation") // Legacy rounding mode constants in BigDecimal
+@AnnotatedFor("nullness")
 public enum RoundingMode {
 
         /**


### PR DESCRIPTION
The only methods that need `@Nullable` are the `equals` methods, and
they're already annotated.