### PR TITLE
Mark `ScheduledThreadPoolExecutor` as annotated for nullness.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ScheduledThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ScheduledThreadPoolExecutor.java
@@ -39,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.checker.signedness.qual.UnknownSignedness;
 import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -136,6 +137,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @since 1.5
  * @author Doug Lea
  */
+@AnnotatedFor("nullness")
 public class ScheduledThreadPoolExecutor
         extends ThreadPoolExecutor
         implements ScheduledExecutorService {


### PR DESCRIPTION
Compare https://github.com/jspecify/jdk/pull/12
