### PR TITLE
Annotate `java.lang.reflect.Array` for nullness.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Array.java
+++ b/src/java.base/share/classes/java/lang/reflect/Array.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.StaticallyExecutable;
+import org.checkerframework.framework.qual.CFComment;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.framework.qual.AnnotatedFor;
@@ -346,6 +347,9 @@ public final
      * argument is negative, or if it is greater than or equal to
      * the length of the specified array
      */
+    @CFComment({"nullness: The passed array might or might not be annotated to allow nullable",
+    "values. We don't know which, so we conservatively issue a warning when someone passes null.",
+    "Compare Method.invoke."})
     public static native void set(Object array, @IndexFor({"#1"}) int index, Object value)
         throws IllegalArgumentException, ArrayIndexOutOfBoundsException;
 

--- a/src/java.base/share/classes/java/lang/reflect/Array.java
+++ b/src/java.base/share/classes/java/lang/reflect/Array.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.StaticallyExecutable;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
@@ -47,7 +48,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * @author Nakul Saraiya
  * @since 1.1
  */
-@AnnotatedFor({"index", "interning"})
+@AnnotatedFor({"index", "interning", "nullness"})
 public final
 @UsesObjectEquals class Array {
 
@@ -157,7 +158,7 @@ public final
      * length of the specified array
      */
     @Pure
-    public static native Object get(Object array, @IndexFor({"#1"}) int index)
+    public static native @Nullable Object get(Object array, @IndexFor({"#1"}) int index)
         throws IllegalArgumentException, ArrayIndexOutOfBoundsException;
 
     /**


### PR DESCRIPTION
See https://github.com/jspecify/jdk/pull/44, but:

Unlike in JSpecify, I've here left the `value` parameter of `set` as
non-nullable. This fits with the conservative approach of the Checker
Framework, since we don't know whether the given array allows null
values or not. Compare our annotations for the
[`get`](https://github.com/eisop/jdk/blob/8d59f980a1c84e52baf6fea4aed444565c37c9af/src/java.base/share/classes/java/lang/reflect/Field.java#L448)
and
[`set`](https://github.com/eisop/jdk/blob/8d59f980a1c84e52baf6fea4aed444565c37c9af/src/java.base/share/classes/java/lang/reflect/Field.java#L830)
methods of `Field`.
