### PR TITLE
Annotate a few `nio` classes for nullness.

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/SelectionKey.java
+++ b/src/java.base/share/classes/java/nio/channels/SelectionKey.java
@@ -27,6 +27,7 @@ package java.nio.channels;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.mustcall.qual.NotOwning;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.lang.invoke.MethodHandles;
@@ -104,7 +105,7 @@ import java.lang.invoke.VarHandle;
  * @see Selector
  */
 
-@AnnotatedFor({"interning", "mustcall"})
+@AnnotatedFor({"interning", "mustcall", "nullness"})
 public abstract @UsesObjectEquals class SelectionKey {
 
     /**
@@ -459,7 +460,7 @@ public abstract @UsesObjectEquals class SelectionKey {
      * @return  The previously-attached object, if any,
      *          otherwise {@code null}
      */
-    public final Object attach(Object ob) {
+    public final @Nullable Object attach(@Nullable Object ob) {
         return ATTACHMENT.getAndSet(this, ob);
     }
 
@@ -469,7 +470,7 @@ public abstract @UsesObjectEquals class SelectionKey {
      * @return  The object currently attached to this key,
      *          or {@code null} if there is no attachment
      */
-    public final Object attachment() {
+    public final @Nullable Object attachment() {
         return attachment;
     }
 

--- a/src/java.base/share/classes/java/nio/file/FileSystems.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystems.java
@@ -26,6 +26,7 @@
 package java.nio.file;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.nio.file.spi.FileSystemProvider;
@@ -89,7 +90,7 @@ import sun.nio.fs.DefaultFileSystemProvider;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullness"})
 public final @UsesObjectEquals class FileSystems {
     private FileSystems() { }
 
@@ -331,7 +332,7 @@ public final @UsesObjectEquals class FileSystems {
      *          if a security manager is installed and it denies an unspecified
      *          permission required by the file system provider implementation
      */
-    public static FileSystem newFileSystem(URI uri, Map<String,?> env, ClassLoader loader)
+    public static FileSystem newFileSystem(URI uri, Map<String,?> env, @Nullable ClassLoader loader)
         throws IOException
     {
         String scheme = uri.getScheme();
@@ -398,7 +399,7 @@ public final @UsesObjectEquals class FileSystems {
      *          permission
      */
     public static FileSystem newFileSystem(Path path,
-                                           ClassLoader loader)
+                                           @Nullable ClassLoader loader)
         throws IOException
     {
         return newFileSystem(path, Map.of(), loader);
@@ -521,7 +522,7 @@ public final @UsesObjectEquals class FileSystems {
      * @since 13
      */
     public static FileSystem newFileSystem(Path path, Map<String,?> env,
-                                           ClassLoader loader)
+                                           @Nullable ClassLoader loader)
         throws IOException
     {
         if (path == null)

--- a/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributeView.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributeView.java
@@ -25,6 +25,9 @@
 
 package java.nio.file.attribute;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.io.IOException;
 
 /**
@@ -100,7 +103,7 @@ import java.io.IOException;
  *
  * @since 1.7
  */
-
+@AnnotatedFor("nullness")
 public interface BasicFileAttributeView
     extends FileAttributeView
 {
@@ -176,7 +179,7 @@ public interface BasicFileAttributeView
      *
      * @see java.nio.file.Files#setLastModifiedTime
      */
-    void setTimes(FileTime lastModifiedTime,
-                  FileTime lastAccessTime,
-                  FileTime createTime) throws IOException;
+    void setTimes(@Nullable FileTime lastModifiedTime,
+                  @Nullable FileTime lastAccessTime,
+                  @Nullable FileTime createTime) throws IOException;
 }


### PR DESCRIPTION
See https://github.com/jspecify/jdk/pull/48

Note that the `eisop` fork is based on a newer JDK than the `jspecify`
fork, so I've annotated an additional overload of
`FileSystems.newFileSystem` here.
