### PR TITLE
Add missing `@Nullable` annotation in `Socket`, and annotate related classes.

### DIFF
--- a/src/java.base/share/classes/java/net/DatagramSocket.java
+++ b/src/java.base/share/classes/java/net/DatagramSocket.java
@@ -26,6 +26,7 @@
 package java.net;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.io.IOException;
@@ -248,7 +249,7 @@ import sun.nio.ch.DefaultSelectorProvider;
  * @see     java.nio.channels.DatagramChannel
  * @since 1.0
  */
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullness"})
 public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
 
     // An instance of DatagramSocketAdaptor, NetMulticastSocket, or null
@@ -330,7 +331,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      * @see SecurityManager#checkListen
      * @since   1.4
      */
-    public DatagramSocket(SocketAddress bindaddr) throws SocketException {
+    public DatagramSocket(@Nullable SocketAddress bindaddr) throws SocketException {
         this(createDelegate(bindaddr, DatagramSocket.class));
     }
 
@@ -389,7 +390,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      * @see SecurityManager#checkListen
      * @since   1.1
      */
-    public DatagramSocket(int port, InetAddress laddr) throws SocketException {
+    public DatagramSocket(int port, @Nullable InetAddress laddr) throws SocketException {
         this(new InetSocketAddress(laddr, port));
     }
 
@@ -408,7 +409,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      *         not supported by this socket.
      * @since 1.4
      */
-    public void bind(SocketAddress addr) throws SocketException {
+    public void bind(@Nullable SocketAddress addr) throws SocketException {
         delegate().bind(addr);
     }
 
@@ -569,7 +570,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      * @return the address to which this socket is connected.
      * @since 1.2
      */
-    public InetAddress getInetAddress() {
+    public @Nullable InetAddress getInetAddress() {
         return delegate().getInetAddress();
     }
 
@@ -604,7 +605,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      * @see #connect(SocketAddress)
      * @since 1.4
      */
-    public SocketAddress getRemoteSocketAddress() {
+    public @Nullable SocketAddress getRemoteSocketAddress() {
         return delegate().getRemoteSocketAddress();
     }
 
@@ -618,7 +619,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      * @see #bind(SocketAddress)
      * @since 1.4
      */
-    public SocketAddress getLocalSocketAddress() {
+    public @Nullable SocketAddress getLocalSocketAddress() {
         return delegate().getLocalSocketAddress();
     }
 
@@ -722,7 +723,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      *          method does not allow the operation
      * @since   1.1
      */
-    public InetAddress getLocalAddress() {
+    public @Nullable InetAddress getLocalAddress() {
         return delegate().getLocalAddress();
     }
 
@@ -1102,7 +1103,7 @@ public @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
      *
      * @since 1.4
      */
-    public DatagramChannel getChannel() {
+    public @Nullable DatagramChannel getChannel() {
         return null;
     }
 

--- a/src/java.base/share/classes/java/net/MulticastSocket.java
+++ b/src/java.base/share/classes/java/net/MulticastSocket.java
@@ -25,6 +25,10 @@
 
 package java.net;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.framework.qual.CFComment;
+
 import java.io.IOException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.MulticastChannel;
@@ -110,6 +114,7 @@ import java.nio.channels.MulticastChannel;
  * @author Pavani Diwanji
  * @since 1.1
  */
+@AnnotatedFor({"nullness"})
 public class MulticastSocket extends DatagramSocket {
 
     @Override
@@ -208,7 +213,7 @@ public class MulticastSocket extends DatagramSocket {
      *
      * @since 1.4
      */
-    public MulticastSocket(SocketAddress bindaddr) throws IOException {
+    public MulticastSocket(@Nullable SocketAddress bindaddr) throws IOException {
         this(createDelegate(bindaddr, MulticastSocket.class));
     }
 
@@ -366,7 +371,7 @@ public class MulticastSocket extends DatagramSocket {
      * @since 1.4
      */
     @Override
-    public void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf)
+    public void joinGroup(SocketAddress mcastaddr, @Nullable NetworkInterface netIf)
             throws IOException {
         super.joinGroup(mcastaddr, netIf);
     }
@@ -382,7 +387,7 @@ public class MulticastSocket extends DatagramSocket {
      * @since 1.4
      */
     @Override
-    public void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf)
+    public void leaveGroup(SocketAddress mcastaddr, @Nullable NetworkInterface netIf)
             throws IOException {
         super.leaveGroup(mcastaddr, netIf);
     }
@@ -401,6 +406,7 @@ public class MulticastSocket extends DatagramSocket {
      * @see        #getInterface()
      */
     @Deprecated(since="14")
+    @CFComment("nullness: TODO: @Nullable parameter or not?")
     public void setInterface(InetAddress inf) throws SocketException {
         delegate().setInterface(inf);
     }
@@ -440,6 +446,7 @@ public class MulticastSocket extends DatagramSocket {
      * @see StandardSocketOptions#IP_MULTICAST_IF
      * @since 1.4
      */
+    @CFComment("nullness: TODO: @Nullable parameter or not?")
     public void setNetworkInterface(NetworkInterface netIf)
         throws SocketException {
         delegate().setNetworkInterface(netIf);

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsIf;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.mustcall.qual.CreatesMustCallFor;
 import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.io.FileDescriptor;
@@ -82,7 +83,7 @@ import sun.net.PlatformSocketImpl;
  * @see     java.nio.channels.ServerSocketChannel
  * @since   1.0
  */
-@AnnotatedFor({"calledmethods", "interning", "mustcall"})
+@AnnotatedFor({"calledmethods", "interning", "mustcall", "nullness"})
 public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
     /**
      * Various states of this socket.
@@ -270,7 +271,7 @@ public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
      * @see SecurityManager#checkListen
      * @since   1.1
      */
-    public ServerSocket(int port, int backlog, InetAddress bindAddr) throws IOException {
+    public ServerSocket(int port, int backlog, @Nullable InetAddress bindAddr) throws IOException {
         setImpl();
         if (port < 0 || port > 0xFFFF)
             throw new IllegalArgumentException(
@@ -346,7 +347,7 @@ public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
      * @since 1.4
      */
     @CreatesMustCallFor
-    public void bind(SocketAddress endpoint) throws IOException {
+    public void bind(@Nullable SocketAddress endpoint) throws IOException {
         bind(endpoint, 50);
     }
 
@@ -376,7 +377,7 @@ public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
      * @since 1.4
      */
     @CreatesMustCallFor
-    public void bind(SocketAddress endpoint, int backlog) throws IOException {
+    public void bind(@Nullable SocketAddress endpoint, int backlog) throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
         if (isBound())
@@ -424,7 +425,7 @@ public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
      *
      * @see SecurityManager#checkConnect
      */
-    public InetAddress getInetAddress() {
+    public @Nullable InetAddress getInetAddress() {
         if (!isBound())
             return null;
         try {
@@ -493,7 +494,7 @@ public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
      * @since 1.4
      */
 
-    public SocketAddress getLocalSocketAddress() {
+    public @Nullable SocketAddress getLocalSocketAddress() {
         if (!isBound())
             return null;
         return new InetSocketAddress(getInetAddress(), getLocalPort());
@@ -744,7 +745,7 @@ public @UsesObjectEquals class ServerSocket implements java.io.Closeable {
      *
      * @since 1.4
      */
-    public @MustCallAlias ServerSocketChannel getChannel(@MustCallAlias ServerSocket this) {
+    public @MustCallAlias @Nullable ServerSocketChannel getChannel(@MustCallAlias ServerSocket this) {
         return null;
     }
 

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -237,7 +237,7 @@ public @UsesObjectEquals class Socket implements java.io.Closeable {
      *
      * @since   1.1
      */
-    protected Socket(SocketImpl impl) throws SocketException {
+    protected Socket(@Nullable SocketImpl impl) throws SocketException {
         checkPermission(impl);
         this.impl = impl;
     }

--- a/src/java.base/share/classes/java/net/SocketOption.java
+++ b/src/java.base/share/classes/java/net/SocketOption.java
@@ -25,6 +25,8 @@
 
 package java.net;
 
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A socket option associated with a socket.
  *
@@ -40,7 +42,7 @@ package java.net;
  *
  * @see StandardSocketOptions
  */
-
+@AnnotatedFor({"nullness"})
 public interface SocketOption<T> {
 
     /**


### PR DESCRIPTION
Compare https://github.com/jspecify/jdk/pull/50

Note that I didn't have to use `@NonNull` on the type argument of
`Class` in `SocketOption`, since the Checker Framework annotates `Class`
to allow nullable type arguments.

Note also that I didn't have to write `<T extends @Nullable Object>` in
`SocketOption` and at its use sites, since the Checker Framework has
that as the default.
