### PR TITLE
Remove redundant upper bound.

### DIFF
--- a/src/java.base/share/classes/java/util/Comparator.java
+++ b/src/java.base/share/classes/java/util/Comparator.java
@@ -389,7 +389,7 @@ public interface Comparator<T> {
      *         {@code Comparator}.
      * @since 1.8
      */
-    public static <T> Comparator<@Nullable T> nullsFirst(@Nullable Comparator<@Nullable ? super T> comparator) {
+    public static <T> Comparator<@Nullable T> nullsFirst(@Nullable Comparator<? super T> comparator) {
         return new Comparators.NullComparator<>(true, comparator);
     }
 
@@ -410,7 +410,7 @@ public interface Comparator<T> {
      *         {@code Comparator}.
      * @since 1.8
      */
-    public static <T> Comparator<@Nullable T> nullsLast(@Nullable Comparator<@Nullable ? super T> comparator) {
+    public static <T> Comparator<@Nullable T> nullsLast(@Nullable Comparator<? super T> comparator) {
         return new Comparators.NullComparator<>(false, comparator);
     }
 


### PR DESCRIPTION
`@Nullable` is already the upper bound for a `super` wildcard, so
there's no need for us to write `@Nullable`: It merely [states the upper
bound](https://checkerframework.org/manual/#annotations-on-wildcards)
that the wildcard [would already
have](https://checkerframework.org/manual/#climb-to-top).

This wildcard has been declared this way [for quite a
while](https://github.com/typetools/jdk/blame/1973fa0811588dd0bb025fdc99345cdb887b3b52/src/java.base/share/classes/java/util/Comparator.java#L392),
so I'm guessing that it's just an oversight, not a workaround for some
bug.
