### PR TITLE
Remove unnecessary `@NonNull` usages from `<T extends Comparable<? super T>>`.

### DIFF
--- a/src/java.base/share/classes/java/util/Comparator.java
+++ b/src/java.base/share/classes/java/util/Comparator.java
@@ -368,7 +368,7 @@ public interface Comparator<T> {
      * @since 1.8
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<@NonNull ? super @NonNull T>> Comparator<T> naturalOrder() {
+    public static <T extends Comparable<? super T>> Comparator<T> naturalOrder() {
         return (Comparator<T>) Comparators.NaturalOrderComparator.INSTANCE;
     }
 


### PR DESCRIPTION
At least, I don't see any reason why they would be necessary. We use
plain `<T extends Comparable<? super T>>` in `Arrays` and `Collections`,
and AFAIK it works fine there.

The `@NonNull` usages [go way
back](https://github.com/typetools/jdk/blame/1973fa0811588dd0bb025fdc99345cdb887b3b52/src/java.base/share/classes/java/util/Comparator.java#L371).
