### PR TITLE
Annotate `InvocationHandler` for nullness.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/InvocationHandler.java
+++ b/src/java.base/share/classes/java/lang/reflect/InvocationHandler.java
@@ -31,6 +31,10 @@ import jdk.internal.reflect.Reflection;
 import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.framework.qual.CFComment;
+
 /**
  * {@code InvocationHandler} is the interface implemented by
  * the <i>invocation handler</i> of a proxy instance.
@@ -44,6 +48,7 @@ import java.util.Objects;
  * @see         Proxy
  * @since       1.3
  */
+@AnnotatedFor({"nullness"})
 public interface InvocationHandler {
 
     /**
@@ -96,7 +101,10 @@ public interface InvocationHandler {
      *
      * @see     UndeclaredThrowableException
      */
-    public Object invoke(Object proxy, Method method, Object[] args)
+    @CFComment("nullness: A null return is allowed only if the Method points to a method whose"
+        + " return value may be null. We don't know whether it does, so we conservatively omit"
+        + " @Nullable on the return type")
+    public Object invoke(Object proxy, Method method, @Nullable Object @Nullable [] args)
         throws Throwable;
 
     /**
@@ -258,7 +266,10 @@ public interface InvocationHandler {
      * @jvms 5.4.3. Method Resolution
      */
     @CallerSensitive
-    public static Object invokeDefault(Object proxy, Method method, Object... args)
+    @CFComment("nullness: Null arguments are allowed only if the Method points to a method whose"
+        + " parameters may be null. We don't know whether it does, so we conservatively omit"
+        + " @Nullable on the parameter types.")
+    public static @Nullable Object invokeDefault(Object proxy, Method method, Object... args)
             throws Throwable {
         Objects.requireNonNull(proxy);
         Objects.requireNonNull(method);


### PR DESCRIPTION
I don't remember whether we have precedent in the Checker Framework for
APIs that users _implement_ and that _sometimes_ can return or accept
`null`. In this PR, I've implemented my interpretation of
"conservative." It may or may not make sense. If we find this hard to
figure out, I'm happy to drop it; I just remembered today that we still
have a stub for `InvocationHandler` inside Google (which matches neither
what I'm proposing here nor [what we did for
JSpecify](https://github.com/jspecify/jdk/commit/6e35cf8b95e94af9f9d522738564560170aa9003)
:)).
