### PR TITLE
Annotate trivial `java.net` exceptions for nullness.

### DIFF
--- a/src/java.base/share/classes/java/net/BindException.java
+++ b/src/java.base/share/classes/java/net/BindException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Signals that an error occurred while attempting to bind a
  * socket to a local address and port.  Typically, the port is
@@ -33,6 +36,7 @@ package java.net;
  * @since   1.1
  */
 
+@AnnotatedFor({"nullness"})
 public class BindException extends SocketException {
     @java.io.Serial
     private static final long serialVersionUID = -5945005768251722951L;
@@ -44,7 +48,7 @@ public class BindException extends SocketException {
      * description of this error.
      * @param msg the detail message
      */
-    public BindException(String msg) {
+    public BindException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/ConnectException.java
+++ b/src/java.base/share/classes/java/net/ConnectException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Signals that an error occurred while attempting to connect a
  * socket to a remote address and port.  Typically, the connection
@@ -33,6 +36,7 @@ package java.net;
  *
  * @since   1.1
  */
+@AnnotatedFor({"nullness"})
 public class ConnectException extends SocketException {
     @java.io.Serial
     private static final long serialVersionUID = 3831404271622369215L;
@@ -44,7 +48,7 @@ public class ConnectException extends SocketException {
      * description of this error.
      * @param msg the detail message
      */
-    public ConnectException(String msg) {
+    public ConnectException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/MalformedURLException.java
+++ b/src/java.base/share/classes/java/net/MalformedURLException.java
@@ -27,6 +27,9 @@ package java.net;
 
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Thrown to indicate that a malformed URL has occurred. Either no
  * legal protocol could be found in a specification string or the
@@ -35,6 +38,7 @@ import java.io.IOException;
  * @author  Arthur van Hoff
  * @since   1.0
  */
+@AnnotatedFor({"nullness"})
 public class MalformedURLException extends IOException {
     @java.io.Serial
     private static final long serialVersionUID = -182787522200415866L;
@@ -51,7 +55,7 @@ public class MalformedURLException extends IOException {
      *
      * @param   msg   the detail message.
      */
-    public MalformedURLException(String msg) {
+    public MalformedURLException(@Nullable String msg) {
         super(msg);
     }
 }

--- a/src/java.base/share/classes/java/net/PortUnreachableException.java
+++ b/src/java.base/share/classes/java/net/PortUnreachableException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Signals that an ICMP Port Unreachable message has been
  * received on a connected datagram.
@@ -32,6 +35,7 @@ package java.net;
  * @since   1.4
  */
 
+@AnnotatedFor({"nullness"})
 public class PortUnreachableException extends SocketException {
     @java.io.Serial
     private static final long serialVersionUID = 8462541992376507323L;
@@ -41,7 +45,7 @@ public class PortUnreachableException extends SocketException {
      * detail message.
      * @param msg the detail message
      */
-    public PortUnreachableException(String msg) {
+    public PortUnreachableException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/ProtocolException.java
+++ b/src/java.base/share/classes/java/net/ProtocolException.java
@@ -27,6 +27,9 @@ package java.net;
 
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Thrown to indicate that there is an error in the underlying
  * protocol, such as a TCP error.
@@ -34,6 +37,7 @@ import java.io.IOException;
  * @author  Chris Warth
  * @since   1.0
  */
+@AnnotatedFor({"nullness"})
 public class ProtocolException extends IOException {
     @java.io.Serial
     private static final long serialVersionUID = -6098449442062388080L;
@@ -44,7 +48,7 @@ public class ProtocolException extends IOException {
      *
      * @param   message   the detail message.
      */
-    public ProtocolException(String message) {
+    public ProtocolException(@Nullable String message) {
         super(message);
     }
 

--- a/src/java.base/share/classes/java/net/SocketException.java
+++ b/src/java.base/share/classes/java/net/SocketException.java
@@ -27,12 +27,16 @@ package java.net;
 
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Thrown to indicate that there is an error creating or accessing a Socket.
  *
  * @author  Jonathan Payne
  * @since   1.0
  */
+@AnnotatedFor({"nullness"})
 public class SocketException extends IOException {
     @java.io.Serial
     private static final long serialVersionUID = -5935874303556886934L;
@@ -43,7 +47,7 @@ public class SocketException extends IOException {
      *
      * @param msg the detail message.
      */
-    public SocketException(String msg) {
+    public SocketException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/UnknownServiceException.java
+++ b/src/java.base/share/classes/java/net/UnknownServiceException.java
@@ -27,6 +27,9 @@ package java.net;
 
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * Thrown to indicate that an unknown service exception has
  * occurred. Either the MIME type returned by a URL connection does
@@ -35,6 +38,7 @@ import java.io.IOException;
  *
  * @since   1.0
  */
+@AnnotatedFor({"nullness"})
 public class UnknownServiceException extends IOException {
     @java.io.Serial
     private static final long serialVersionUID = -4169033248853639508L;
@@ -52,7 +56,7 @@ public class UnknownServiceException extends IOException {
      *
      * @param   msg   the detail message.
      */
-    public UnknownServiceException(String msg) {
+    public UnknownServiceException(@Nullable String msg) {
         super(msg);
     }
 }


### PR DESCRIPTION
All of these have a no-arg constructor, so there is already a way to
create an instance with no message. Thus, letting users pass a null
message to the `(String)` constructor doesn't introduce any problems.
