### PR TITLE
Mark `TimeUnit` as annotated for nullness.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/TimeUnit.java
+++ b/src/java.base/share/classes/java/util/concurrent/TimeUnit.java
@@ -74,7 +74,7 @@ import java.util.Objects;
  * @since 1.5
  * @author Doug Lea
  */
-@AnnotatedFor({"lock"})
+@AnnotatedFor({"lock", "nullness"})
 public enum TimeUnit {
     /**
      * Time unit representing one thousandth of a microsecond.


### PR DESCRIPTION
This requires no annotations.