### PR TITLE
Add `@Nullable` to `Class.componentType()` and the method it overrides.

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4494,7 +4494,7 @@ public final @Interned class Class<@UnknownKeyFor T> implements java.io.Serializ
      */
     @Override
     @Pure
-    public Class<?> componentType() {
+    public @Nullable Class<?> componentType() {
         return isArray() ? componentType : null;
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/TypeDescriptor.java
+++ b/src/java.base/share/classes/java/lang/invoke/TypeDescriptor.java
@@ -24,6 +24,7 @@
  */
 package java.lang.invoke;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.List;
 
 /**
@@ -81,7 +82,7 @@ public interface TypeDescriptor {
          * @return the component type, or {@code null} if this field descriptor does
          * not describe an array type
          */
-        F componentType();
+        @Nullable F componentType();
 
         /**
          * Return a descriptor for the array type whose component type is described by this


### PR DESCRIPTION
(I somewhat suspect that the annotation on `componentType()` in
`TypeDescriptor` is enough to fully annotate that class for nullness,
but I haven't tried hard to convince myself of that.)
