### PR TITLE
Mark `Spliterators` as `@AnnotatedFor("nullness")`.

### DIFF
--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -31,6 +31,8 @@ import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 /**
  * Static classes and methods for operating on or creating instances of
@@ -41,6 +43,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @see Spliterator
  * @since 1.8
  */
+@AnnotatedFor("nullness")
 public final class Spliterators {
 
     // Suppresses default constructor, ensuring non-instantiability.
@@ -144,7 +147,7 @@ public final class Spliterators {
      * @throws NullPointerException if the given array is {@code null}
      * @see Arrays#spliterator(Object[])
      */
-    public static <T> Spliterator<T> spliterator(Object[] array,
+    public static <T> Spliterator<@PolyNull T> spliterator(@PolyNull Object[] array,
                                                  int additionalCharacteristics) {
         return new ArraySpliterator<>(Objects.requireNonNull(array),
                                       additionalCharacteristics);
@@ -179,7 +182,7 @@ public final class Spliterators {
      *         {@code toIndex} is greater than the array size
      * @see Arrays#spliterator(Object[], int, int)
      */
-    public static <T> Spliterator<T> spliterator(Object[] array, int fromIndex, int toIndex,
+    public static <T> Spliterator<@PolyNull T> spliterator(@PolyNull Object[] array, int fromIndex, int toIndex,
                                                  int additionalCharacteristics) {
         checkFromToBounds(Objects.requireNonNull(array).length, fromIndex, toIndex);
         return new ArraySpliterator<>(array, fromIndex, toIndex, additionalCharacteristics);


### PR DESCRIPTION
Compare https://github.com/jspecify/jdk/pull/66.

One thing we could discuss here is what to do about
[`spliterator(Object[], int`](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/Spliterators.html#spliterator(java.lang.Object%5B%5D,int))
and friends. In the JSpecify PR, I annotate the array-element type as
`@Nullable`. That's unsound, since the API lets you create a
`Spliterator` of a non-nullable type `T` from a `@Nullable Object[]`. In
fairness, the entire API is unsound, since it also lets you create a
`Spliterator<String>` from an `Integer[]` :) But we don't have to make
it worse. With the Checker Framework, we can use `@PolyNull`, which
seems like probably the right tool. I'm using it in this PR.
