### PR TITLE
Ignore class files in source folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ NashornProfile.txt
 **/JTreport/**
 **/JTwork/**
 /src/utils/LogCompilation/target/
+/src/**/*.class


### PR DESCRIPTION
This is desired because when I use patch module to typecheck JDK and it will generate .class files in source folder.

Why source folder only: there are valid .class files in test folder for example https://github.com/eisop/jdk/blob/master/test/jdk/sun/misc/Hello.class.