### PR TITLE
Always run Gradle on JDK 21; also run CI tests on JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: ./checker/bin-devel/test-${{ matrix.script }}.sh
         working-directory: ../checker-framework
         env:
-          ORG_GRADLE_PROJECT_useJdkVersion: ${{ matrix.java.version }}
+          ORG_GRADLE_PROJECT_useJdkVersion: ${{ matrix.java_version }}
 
   extra:
     name: ${{ matrix.script }} on JDK ${{ matrix.java_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           # Install JDK 21 first, to make it available to Gradle using `gradle.properties` below.
-          java-version: '21'
+          java-version: 21
           distribution: 'temurin'
-
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'temurin'
-
       - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
         run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           # Install JDK 21 first, to make it available to Gradle using `gradle.properties` below.
-          java-version: 21
+          java-version: '21'
           distribution: 'temurin'
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v4
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java_version: [ '21' ]
+        java_version: ['21']
     env:
       JAVA_VERSION: ${{ matrix.java_version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI tests
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
+  push:
     branches: [ "master" ]
 
 concurrency:
@@ -48,7 +47,7 @@ jobs:
     strategy:
       matrix:
         script: ['cftests-junit', 'cftests-nonjunit']
-        java_version: [8, 11, 17, 21, 23]
+        java_version: ['8', '11', '17', '21', '24', '25-ea']
     continue-on-error: true
     env:
       JAVA_VERSION: ${{ matrix.java_version }}
@@ -72,7 +71,7 @@ jobs:
         run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.1.0
+        uses: gradle/actions/setup-gradle@v4.3.1
     
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.9.0
@@ -104,11 +103,12 @@ jobs:
       fail-fast: true
       matrix:
         script: ['plume-lib', 'daikon']
-        java_version: [17]
+        java_version: ['21']
     env:
       JAVA_VERSION: ${{ matrix.java_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v4
         with:
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java_version: [ 17 ]
+        java_version: [ '21' ]
     env:
       JAVA_VERSION: ${{ matrix.java_version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,24 @@ jobs:
     env:
       JAVA_VERSION: ${{ matrix.java_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21 for Gradle to run on
+        uses: actions/setup-java@v4
+        with:
+          # Install JDK 21 first, to make it available to Gradle using `gradle.properties` below.
+          java-version: 21
+          distribution: 'temurin'
+
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'temurin'
-    
+
+      - name: Inject JAVA_HOME_21_64 into `gradle.properties` to always use JDK 21 for Gradle
+        run: mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_HOME_21_X64" >> ~/.gradle/gradle.properties
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4.1.0
     
@@ -83,6 +94,8 @@ jobs:
       - name: Run test script checker/bin-devel/test-${{ matrix.script }}.sh
         run: ./checker/bin-devel/test-${{ matrix.script }}.sh
         working-directory: ../checker-framework
+        env:
+          ORG_GRADLE_PROJECT_useJdkVersion: ${{ matrix.java.version }}
 
   extra:
     name: ${{ matrix.script }} on JDK ${{ matrix.java_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           # Install JDK 21 first, to make it available to Gradle using `gradle.properties` below.
-          java-version: 21
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Set up JDK ${{ matrix.java_version }}


### PR DESCRIPTION
CF updated CI config in https://github.com/eisop/checker-framework/pull/1190, this PR updated the CI accordingly in JDK.