### PR TITLE
Standardize second input for `compute` `BiFunction` on `? super @Nullable V`.

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1653,7 +1653,7 @@ public class Collections {
 
         @Override
         public @PolyNull V compute(K key,
-                BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
             throw new UnsupportedOperationException();
         }
 
@@ -2863,7 +2863,7 @@ public class Collections {
         }
         @Override
         public @PolyNull V compute(K key,
-                BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
             synchronized (mutex) {return m.compute(key, remappingFunction);}
         }
         @Override
@@ -3957,7 +3957,7 @@ public class Collections {
 
         @Override
         public @PolyNull V compute(K key,
-                BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
             return m.compute(key, typeCheck(remappingFunction));
         }
 
@@ -4971,7 +4971,7 @@ public class Collections {
 
         @Override
         public @PolyNull V compute(K key,
-                BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
             throw new UnsupportedOperationException();
         }
 
@@ -5322,7 +5322,7 @@ public class Collections {
 
         @Override
         public @PolyNull V compute(K key,
-                BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
             throw new UnsupportedOperationException();
         }
 

--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -1331,7 +1331,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
      */
     @Override
     public @PolyNull V compute(K key,
-                     BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                     BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
         if (remappingFunction == null)
             throw new NullPointerException();
         int hash = hash(key);

--- a/src/java.base/share/classes/java/util/Hashtable.java
+++ b/src/java.base/share/classes/java/util/Hashtable.java
@@ -1151,7 +1151,7 @@ public class Hashtable<K extends @NonNull Object,V extends @NonNull Object>
      * remapping function modified this map
      */
     @Override
-    public synchronized @PolyNull V compute(K key, BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+    public synchronized @PolyNull V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
 
         Entry<?,?> tab[] = table;

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -1878,7 +1878,7 @@ public class TreeMap<K,V>
             return m.computeIfAbsent(key, mappingFunction);
         }
 
-        public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        public V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
             if (!inRange(key)) {
                 // Do not throw if remapping function returns null
                 // to preserve compatibility with default computeIfAbsent implementation

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentMap.java
@@ -424,7 +424,7 @@ public interface ConcurrentMap<K extends @NonNull Object,V extends @NonNull Obje
      */
     @Override
     default @PolyNull V compute(K key,
-                      BiFunction<? super K, ? super V, ? extends @PolyNull V> remappingFunction) {
+                      BiFunction<? super K, ? super @Nullable V, ? extends @PolyNull V> remappingFunction) {
         retry: for (;;) {
             V oldValue = get(key);
             // if putIfAbsent fails, opportunistically use its return value

--- a/test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java
+++ b/test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java
@@ -142,7 +142,7 @@ public class DelegatingIteratorForEachRemaining {
         @Override public V replace(K key, V value) { return delegate.replace(key, value); }
         @Override public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) { return delegate.computeIfAbsent(key, mappingFunction); }
         @Override public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) { return delegate.computeIfPresent(key, remappingFunction); }
-        @Override public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) { return delegate.compute(key, remappingFunction); }
+        @Override public V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) { return delegate.compute(key, remappingFunction); }
         @Override public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) { return delegate.merge(key, value, remappingFunction); }
     }
 


### PR DESCRIPTION
That is already how we have it in `Map` and `ConcurrentHashMap`. It also
matches JSpecify.

I haven't tried to correct anything else in these signatures, some of
which are in internal APIs that we don't need to annotate. I'm happy to
revert such APIs if you'd like.
